### PR TITLE
feat : #9 회원가입 함수, 유저 데이터 리덕스로 관리

### DIFF
--- a/src/app/_hooks/useAppDispatch.ts
+++ b/src/app/_hooks/useAppDispatch.ts
@@ -1,0 +1,6 @@
+import { useDispatch } from 'react-redux';
+import { AppDispatch } from '../_store/store';
+
+const useAppDispatch: () => AppDispatch = useDispatch;
+
+export default useAppDispatch;

--- a/src/app/_hooks/useAppSelector.ts
+++ b/src/app/_hooks/useAppSelector.ts
@@ -1,0 +1,6 @@
+import { useSelector, TypedUseSelectorHook } from 'react-redux';
+import { RootState } from '../_store/store';
+
+const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;
+
+export default useAppSelector;

--- a/src/app/_slice/userDataSlice.ts
+++ b/src/app/_slice/userDataSlice.ts
@@ -1,0 +1,59 @@
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
+import axios from 'axios';
+import type { PayloadAction } from '@reduxjs/toolkit';
+import { RootState } from '../_store/store';
+
+interface UserDataPayload {
+  email: string;
+  nickname: string;
+  password: string;
+}
+
+interface UserDataState {
+  data: UserDataPayload | null;
+}
+
+const initialState: UserDataState = {
+  data: null,
+};
+
+const asynchFetchSignUp = createAsyncThunk(
+  'userDataSlice/asynchFetchSignup',
+
+  async (userData: UserDataPayload) => {
+    const { email, nickname, password } = userData;
+
+    const response = await axios.post(
+      'https://sp-taskify-api.vercel.app/4-1/users',
+      {
+        email,
+        nickname,
+        password,
+      },
+    );
+    return response.data;
+  },
+);
+
+const userDataSlice = createSlice({
+  name: 'userDataSlice',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(
+      asynchFetchSignUp.fulfilled,
+      (state, action: PayloadAction<UserDataPayload>) => {
+        state.data = action.payload;
+      },
+    );
+  },
+});
+
+export default userDataSlice.reducer;
+
+export const userActions = {
+  ...userDataSlice.actions,
+  asynchFetchSignUp,
+};
+
+export const userData = (state: RootState) => state.userData.data;

--- a/src/app/_store/store.ts
+++ b/src/app/_store/store.ts
@@ -1,7 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
 
+import userDataReducer from '../_slice/userDataSlice';
+
 const store = configureStore({
-  reducer: {},
+  reducer: {
+    userData: userDataReducer,
+  },
 });
+
+export type RootState = ReturnType<typeof store.getState>;
+export type AppDispatch = typeof store.dispatch;
 
 export default store;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,34 @@
+'use client';
+
+import useAppSelector from './_hooks/useAppSelector';
+import useAppDispatch from './_hooks/useAppDispatch';
+import { userData, userActions } from './_slice/userDataSlice';
+
 export default function Home() {
   const a: string = 'bb';
-  return <div>{a}</div>;
+
+  const userInfo = useAppSelector(userData);
+  const dispatch = useAppDispatch();
+
+  const handleSignUp = (email: string, nickname: string, password: string) => {
+    dispatch(
+      userActions.asynchFetchSignUp({
+        email,
+        nickname,
+        password,
+      }),
+    );
+  };
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() =>
+          handleSignUp('testPlanyang@naver.com', '플래냥테스트계정', 'AS123456')
+        }
+      >
+        회원가입
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## 💻 작업 내용

reduxToolkit으로 회원가입 함수와 불러온 유저 데이터를 전역적으로 사용 가능하게 만들었습니다

## 🖼️ 스크린샷

![스크린샷 2024-04-15 174926](https://github.com/sprint-part3-team1/Planyang/assets/90647684/33f4ce48-d8fb-46ac-9c03-679fb614f36d)


사용예시 : useAppSelector 훅으로 redux store에 저장되어있는 데이터를 가져올수 있습니다,
useAppDispatch 훅으로 api 요청을 할수 있습니다 리덕스에 있는 데이터와 함수는 _slice 폴더를 참고해주시면됩니다 궁금한점 있으면 질문해주세요



