### PR TITLE
user_icon_component_topic

### DIFF
--- a/src/app/_components/NumberIcon.module.css
+++ b/src/app/_components/NumberIcon.module.css
@@ -1,0 +1,13 @@
+.iconWrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 38px;
+    height: 38px;
+    border: 2px solid var(--white_FFFFFF);
+    border-radius: 30px;
+    font-size: var(--font16);
+    font-weight: 600;
+    background-color: #F4D7DA;
+    color: #D25B68;
+}

--- a/src/app/_components/NumberIcon.tsx
+++ b/src/app/_components/NumberIcon.tsx
@@ -4,7 +4,7 @@ import {NumberIconProps} from "@/app/_types/NumberIconProps";
 
 const NumberIcon = ({count} : NumberIconProps) => {
     return(
-        <div className={styles.iconWrapper}>{`+${count}`}</div>
+        <div className={styles.iconWrapper}>{`+${Math.min(count, 99)}`}</div>
     )
 }
 

--- a/src/app/_components/NumberIcon.tsx
+++ b/src/app/_components/NumberIcon.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import styles from './NumberIcon.module.css'
+import {NumberIconProps} from "@/app/_types/NumberIconProps";
+
+const NumberIcon = ({count} : NumberIconProps) => {
+    return(
+        <div className={styles.iconWrapper}>{`+${count}`}</div>
+    )
+}
+
+export default NumberIcon;

--- a/src/app/_components/UserIcon.module.css
+++ b/src/app/_components/UserIcon.module.css
@@ -1,0 +1,15 @@
+.iconWrapper {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 38px;
+    height: 38px;
+    border: 2px solid var(--white_FFFFFF);
+    border-radius: 30px;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    font-size: var(--font16);
+    font-weight: 600;
+    color: var(--white_FFFFFF);
+}

--- a/src/app/_components/UserIcon.tsx
+++ b/src/app/_components/UserIcon.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import styles from './UserIcon.module.css'
+import {UserIconProps} from "@/app/_types/UserIconProps";
+import {createRandomColor} from "@/app/_utils/colorUtils";
+
+const UserIcon = ({nickname, profileImageUrl} : UserIconProps) => {
+    const customImage = () => {
+        const backgroundColor = createRandomColor(nickname);
+
+        if(profileImageUrl != null ) {
+            return {
+                backgroundImage: profileImageUrl,
+            }
+        }
+        else return {
+            backgroundColor: backgroundColor
+        }
+    }
+
+    return (
+        <div className={styles.iconWrapper} style={customImage()}>
+            {
+                profileImageUrl == null ? nickname.at(0) : null
+            }
+        </div>
+    )
+}
+
+export default UserIcon;

--- a/src/app/_components/UserIconList.module.css
+++ b/src/app/_components/UserIconList.module.css
@@ -1,0 +1,12 @@
+.entireWrapper {
+    display: flex;
+    position: relative;
+    background-color: var(--white_FFFFFF);
+    width: 100%;
+    height: 38px;
+}
+
+.iconWrapper {
+    display: flex;
+    position: absolute;
+}

--- a/src/app/_components/UserIconList.tsx
+++ b/src/app/_components/UserIconList.tsx
@@ -1,0 +1,75 @@
+import React, {useEffect, useRef, useState} from 'react'
+import styles from './UserIconList.module.css'
+import {MemberListDto} from "@/app/_types/_dto/MemberListDto";
+import UserIcon from "@/app/_components/UserIcon";
+import NumberIcon from "@/app/_components/NumberIcon";
+
+const UserIconList = ({members, totalCount} : MemberListDto) => {
+    const DESKTOP_WIDTH = 1024;
+
+    let calcWrapperWidth = (count: number) => {
+        if(count <= 0) {
+            return 0;
+        } else if(count === 1) {
+            return 38;
+        } else {
+            return 38 + 30 * (count - 1);
+        }
+    }
+
+    let leftValue = (index: number) => 30 * (index);
+
+    const [listStyle, setListStyle] = useState(window.innerWidth >= DESKTOP_WIDTH);
+    const lastWidth = useRef(window.innerWidth);
+
+    const setListType = (breakPoint: number, count: number) => {
+        return new Array(Math.min(breakPoint, count)).fill(null).map((value, index) => {
+            return index + 1 < breakPoint ?
+                <div key={index} className={styles.iconWrapper} style={{left: leftValue(index)}}>
+                    <UserIcon key={index} nickname={members[index].nickname} profileImageUrl={members[index].profileImageUrl}/>
+                </div>
+                 :
+                count >= breakPoint ?
+                    <div key={index} className={styles.iconWrapper} style={{left: leftValue(index)}}>
+                        <NumberIcon key={index} count={count - breakPoint + 1}/>
+                    </div>: null;
+        })
+    }
+
+    useEffect(() => {
+        const handleResize = () => {
+            if(listStyle && (window.innerWidth < DESKTOP_WIDTH)) {
+                setListStyle(false);
+            } else if(!listStyle && (window.innerWidth >= DESKTOP_WIDTH)) {
+                setListStyle(true);
+            }
+            lastWidth.current = window.innerWidth;
+        }
+
+        window.addEventListener('resize', handleResize);
+
+        return () => {
+            window.removeEventListener('resize', handleResize);
+        }
+    }, [listStyle]);
+
+    return (
+        <>
+            {
+                listStyle ?
+                    <div className={styles.entireWrapper} style={{width: calcWrapperWidth(Math.min(totalCount, 5))}}>
+                        {
+                            setListType(5, totalCount)
+                        }
+                    </div> :
+                    <div className={styles.entireWrapper} style={{width: calcWrapperWidth(Math.min(totalCount, 3))}}>
+                        {
+                            setListType(3, totalCount)
+                        }
+                    </div>
+            }
+        </>
+    )
+}
+
+export default UserIconList;

--- a/src/app/_types/NumberIconProps.ts
+++ b/src/app/_types/NumberIconProps.ts
@@ -1,0 +1,3 @@
+export interface NumberIconProps {
+    count: number;
+}

--- a/src/app/_types/UserIconProps.ts
+++ b/src/app/_types/UserIconProps.ts
@@ -1,0 +1,4 @@
+export interface UserIconProps {
+    readonly nickname: string;
+    readonly profileImageUrl?: string | null;
+}

--- a/src/app/_types/_dto/MemberListDto.ts
+++ b/src/app/_types/_dto/MemberListDto.ts
@@ -1,0 +1,15 @@
+export interface MemberListDto {
+    readonly members: Member[];
+    readonly totalCount: number;
+}
+
+interface Member {
+    readonly id: number;
+    readonly userId: number;
+    readonly email: string;
+    readonly nickname: string;
+    readonly profileImageUrl: string | null;
+    readonly createdAt: string;
+    readonly updatedAt: string;
+    readonly isOwner: boolean;
+}

--- a/src/app/_utils/colorUtils.ts
+++ b/src/app/_utils/colorUtils.ts
@@ -1,0 +1,56 @@
+export const createRandomColor = (text: string) => {
+    const crypto = require('crypto');
+    const colorCode = crypto.createHash('md5').update(text).digest('hex').substring(0, 6);
+
+    let originR = parseInt(colorCode.substring(0, 2), 16);
+    let originG = parseInt(colorCode.substring(2, 4), 16);
+    let originB = parseInt(colorCode.substring(4, 6), 16);
+
+    const {r, g, b} = adjustToPastel(originR, originG, originB);
+
+    return `#${r.toString(16) + g.toString(16) + b.toString(16)}`;
+}
+
+const rgbToHsl = (r: number, g: number, b: number) => {
+    r /= 255;
+    g /= 255;
+    b /= 255;
+
+    const l = Math.max(r, g, b);
+    const s = 1 - Math.min(r, g, b);
+
+    const h = s ?
+        l === r ?
+            (g - b) / s : l === g ?
+            2 + (b - r) / s :
+            4 + (r - g) / s :
+        0;
+
+    return {
+        h: 60 * h < 0 ? 60 * h + 360 : 60 * h,
+        s: 100 * (s ? (l <= 0.5 ? s / (2 * l - s) : s / (2 - (2 * l - s))) : 0),
+        l: (100 * (2 * l - s)) / 2
+    }
+}
+
+const hslToRgb = (h: number, s: number, l: number) => {
+    s /= 100;
+    l /= 100;
+    const k = (n: number) => (n + h / 30) % 12;
+    const a = s * Math.min(l, 1 - l);
+    const f = (n: number) => l - a * Math.max(-1, Math.min(k(n) - 3, Math.min(9 - k(n), 1)));
+    return {
+        r: Math.round(255 * f(0)),
+        g: Math.round(255 * f(8)),
+        b: Math.round(255 * f(4))
+    }
+}
+
+const adjustToPastel = (r: number, g: number, b: number) => {
+    let {h, s, l} = rgbToHsl(r, g, b);
+
+    s *= 0.5;
+    l = 80;
+
+    return hslToRgb(h, s, l);
+}


### PR DESCRIPTION
## 💻 작업 내용

- UserIcon : 유저의 프로필 아이콘을 표시해줄 컴포넌트.
- NumberIcon : 유저 리스트에서 표시되지 않은 추가 유저의 수를 표시해줄 컴포넌트.
- UserIconList : 유저 리스트를 반응형 디자인에 맞게 볼 수 있도록 표시해줄 컴포넌트.

## 🖼️ 스크린샷

![image](https://github.com/sprint-part3-team1/Planyang/assets/106132097/68dda0fd-e183-4644-b3d3-4a1bf737da2d)
![image](https://github.com/sprint-part3-team1/Planyang/assets/106132097/4e16ce13-67d0-4346-a17c-de396072ef81)

## 🚨 관련 이슈 및 참고 사항

- UserIcon 컴포넌트에서 유저의 프로필 이미지 주소가 등록되지 않은 경우, 닉네임의 첫글자를 프로필로 사용하며, 이 때 배경은 닉네임을 md5로 해싱 처리해 닉네임에 맞는 색깔 코드가 부여되고, 색깔 코드는 HSL색상으로 변환하여 밝기를 일정 수치로 조절 및 채도를 감소시켜 전체적으로 파스텔 톤이 생성되도록 작성. 때문에 닉네임이 변하지 않는 한 프로필의 배경 색깔이 변하지 않으며, 별도로 색상 정보를 DB에 저장하지 않아도 됨.
- NumberIcon은 추가로 +99까지 표시할 수 있도록 하여 overflow가 되지 않도록 방지.
- UserIconList는 아이콘의 갯수에 따라 유동적으로 크기 및 프로필 아이콘의 위치가 변경되어 width와 position을 별도로 지정하지 않아도 되고, 하나의 개체로 사용할 수 있도록 함.
