### PR TITLE
feat: dashboardPage_topic

### DIFF
--- a/src/app/(route)/dashboard/[id]/page.module.css
+++ b/src/app/(route)/dashboard/[id]/page.module.css
@@ -1,16 +1,27 @@
 .container {
   width: 100%;
-  height: auto;
-  padding-left: 30rem;
-  overflow: scroll;
+  height: 100vh;
+  overflow: auto;
   background: var(--gray_FAFAFA);
 }
 
 .columnsContainer {
   display: flex;
   flex-direction: row;
+
+  @media (max-width: 1023px) {
+    flex-direction: column;
+  }
 }
 
 .buttonContainer {
   padding-top: 7rem;
+
+  @media (max-width: 1023px) {
+    padding: 2.2rem 0 2.2rem 2rem;
+  }
+
+  @media (max-width: 767px) {
+    padding: 1.7rem 1.2rem 1.7rem 1.2rem;
+  }
 }

--- a/src/app/(route)/dashboard/_components/Card.module.css
+++ b/src/app/(route)/dashboard/_components/Card.module.css
@@ -6,6 +6,7 @@
   border-radius: 0.6rem;
   border: 0.1rem solid var(--gray_D9D9D9);
   background: var(--white_FFFFFF);
+  cursor: pointer;
 }
 
 .imageContainer {
@@ -16,6 +17,7 @@
   border-radius: 0.6rem;
   border: 0.1rem solid var(--gray_D9D9D9);
   background: var(--white_FFFFFF);
+  cursor: pointer;
 }
 
 .imageTitle,

--- a/src/app/(route)/dashboard/_components/Card.tsx
+++ b/src/app/(route)/dashboard/_components/Card.tsx
@@ -5,6 +5,8 @@ import Image from 'next/image';
 import TagIcon from '@/app/_components/TagIcon';
 import { CardProps } from '@/app/_types/CardProps';
 import UserIcon from '@/app/_components/UserIcon';
+import ModalPortal from '@/app/_components/modal/modalPortal/ModalPortal';
+import MODAL_TYPES from '@/app/constants/modalTypes';
 import styles from './Card.module.css';
 
 const Card = ({
@@ -14,11 +16,13 @@ const Card = ({
   tagNameArr,
   date,
   image,
+  cardInfo,
 }: CardProps) => {
   const CALENDAR_ICON = '/assets/icons/calendar.svg';
 
   const [isMobile, setIsMobile] = useState(false);
   const [isTablet, setIsTablet] = useState(false);
+  const [openModalType, setOpenModalType] = useState('');
 
   useEffect(() => {
     const handleResize = () => {
@@ -35,7 +39,10 @@ const Card = ({
   }, []);
 
   return (
-    <div className={image ? styles.imageContainer : styles.container}>
+    <div
+      className={image ? styles.imageContainer : styles.container}
+      onClick={() => setOpenModalType(MODAL_TYPES.taskCard)}
+    >
       {image ? (
         <Image
           id={styles.cardImage}
@@ -102,6 +109,11 @@ const Card = ({
           </div>
         </>
       )}
+      <ModalPortal
+        openModalType={openModalType}
+        setOpenModalType={setOpenModalType}
+        requestId={cardInfo.id}
+      />
     </div>
   );
 };

--- a/src/app/(route)/dashboard/_components/Column.module.css
+++ b/src/app/(route)/dashboard/_components/Column.module.css
@@ -1,6 +1,5 @@
 .container {
   width: 35.4rem;
-  height: 101rem;
   flex-shrink: 0;
   padding: 2.2rem 2rem 2.2rem 2rem;
 }
@@ -65,14 +64,12 @@
 @media (max-width: 1023px) {
   .container {
     width: 58.4rem;
-    height: 34.6rem;
   }
 }
 
 @media (max-width: 767px) {
   .container {
     width: 30.8rem;
-    height: 47rem;
     padding: 1.7rem 1.2rem 1.7rem 1.2rem;
   }
 

--- a/src/app/(route)/dashboard/_components/Column.tsx
+++ b/src/app/(route)/dashboard/_components/Column.tsx
@@ -125,6 +125,8 @@ const Column = ({
       <ModalPortal
         openModalType={openModalType}
         setOpenModalType={setOpenModalType}
+        inputInitialValue={columnData.title}
+        requestId={columnData.id}
       />
     </div>
   );

--- a/src/app/(route)/dashboard/_components/Column.tsx
+++ b/src/app/(route)/dashboard/_components/Column.tsx
@@ -119,6 +119,7 @@ const Column = ({
             tagNameArr={card.tags}
             date={card.dueDate}
             image={null}
+            cardInfo={card}
           />
         ))}
       </div>

--- a/src/app/_components/modal/ModalContents.tsx
+++ b/src/app/_components/modal/ModalContents.tsx
@@ -18,6 +18,7 @@ const ModalContents = ({
   openModalType,
   setOpenModalType,
   inputInitialValue,
+  requestId,
 }: ModalContentFuncPropsType): React.ReactNode => {
   let modalContent: React.ReactNode = null;
   switch (openModalType) {
@@ -36,6 +37,7 @@ const ModalContents = ({
           openModalType={openModalType}
           setOpenModalType={setOpenModalType}
           inputInitialValue={inputInitialValue}
+          requestId={requestId}
         />
       );
       break;

--- a/src/app/_components/modal/ModalContents.tsx
+++ b/src/app/_components/modal/ModalContents.tsx
@@ -94,6 +94,7 @@ const ModalContents = ({
         <TaskCardModal
           openModalType={openModalType}
           setOpenModalType={setOpenModalType}
+          requestId={requestId}
         />
       );
       break;

--- a/src/app/_components/modal/columnManagerModal/ColumnManageModal.tsx
+++ b/src/app/_components/modal/columnManagerModal/ColumnManageModal.tsx
@@ -4,12 +4,15 @@ import VIEWPORT_TYPES from '@/app/constants/viewPortTypes';
 import useGetViewportSize from '@/app/_hooks/useGetViewportSize';
 import ModalContainer from '@/app/_components/modal/modalContainer/ModalContainer';
 import { ModalPropsType } from '@/app/_types/modalProps';
+import useAppDispatch from '@/app/_hooks/useAppDispatch';
+import { columnActions } from '@/app/_slice/columnSlice';
 import CheckCancleButton from '../checkCancleButton/CheckCancleButton';
 
 const ColumnManageModal = ({
   openModalType,
   setOpenModalType,
   inputInitialValue,
+  requestId,
 }: ModalPropsType) => {
   const INPUT_WIDTH = {
     [VIEWPORT_TYPES.deskTop]: 48.4,
@@ -18,7 +21,28 @@ const ColumnManageModal = ({
   };
 
   const viewPortType = useGetViewportSize();
+  const dispatch = useAppDispatch();
   const inputRef = useRef<HTMLInputElement | null>(null);
+
+  const updateColumnTitle = async (columnId: number, title: string) => {
+    try {
+      await dispatch(
+        columnActions.asyncFetchPutColumn({
+          columnId,
+          title,
+        }),
+      );
+    } catch (error) {
+      console.error('Error update column:', error);
+    }
+  };
+
+  const produceButtonHandler = () => {
+    if (inputRef.current?.value === '') return;
+
+    updateColumnTitle(requestId, inputRef.current?.value);
+    setOpenModalType('');
+  };
 
   useEffect(() => {
     if (inputRef.current && inputInitialValue) {
@@ -39,6 +63,7 @@ const ColumnManageModal = ({
         checkText="변경"
         openModalType={openModalType}
         setOpenModalType={setOpenModalType}
+        checkButtonHandler={produceButtonHandler}
         deleteMode
       />
     </ModalContainer>

--- a/src/app/_components/modal/modalPortal/ModalPortal.tsx
+++ b/src/app/_components/modal/modalPortal/ModalPortal.tsx
@@ -8,6 +8,7 @@ const ModalPortal = ({
   openModalType,
   setOpenModalType,
   inputInitialValue,
+  requestId,
 }: ModalPortalPropsType) => {
   if (openModalType === '') return null;
 
@@ -16,6 +17,7 @@ const ModalPortal = ({
     openModalType,
     setOpenModalType,
     inputInitialValue,
+    requestId,
   });
 
   return createPortal(

--- a/src/app/_components/modal/newColumnModal/NewColumnModal.tsx
+++ b/src/app/_components/modal/newColumnModal/NewColumnModal.tsx
@@ -1,14 +1,37 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ModalContainer from '@/app/_components/modal/modalContainer/ModalContainer';
 import VIEWPORT_TYPES from '@/app/constants/viewPortTypes';
 import useGetViewportSize from '@/app/_hooks/useGetViewportSize';
 import { ModalPropsType } from '@/app/_types/modalProps';
 import Input from '@/app/_components/Input';
+import useAppDispatch from '@/app/_hooks/useAppDispatch';
+import { useParams } from 'next/navigation';
+import { columnActions, columnData } from '@/app/_slice/columnSlice';
 import CheckCancleButton from '../checkCancleButton/CheckCancleButton';
 
 const NewColumnModal = ({ setOpenModalType }: ModalPropsType) => {
+  const dispatch = useAppDispatch();
+  const params = useParams();
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  const createColumn = async (title: string, dashboardId: number) => {
+    try {
+      await dispatch(
+        columnActions.asyncFetchCreateColumn({
+          title,
+          dashboardId,
+        }),
+      );
+    } catch (error) {
+      console.error('Error create column:', error);
+    }
+  };
+
   const produceButtonHandler = () => {
-    /** 생성 버튼을 누르면 실행되는 함수 작성 */
+    if (titleRef.current?.value === '') return;
+
+    createColumn(titleRef.current?.value, Number(params.id));
+    setOpenModalType('');
   };
 
   const INPUT_WIDTH = {
@@ -25,6 +48,7 @@ const NewColumnModal = ({ setOpenModalType }: ModalPropsType) => {
         inputName="이름"
         inputType="text"
         inputWidth={INPUT_WIDTH[viewPortType]}
+        inputRef={titleRef}
         errorState={false}
       />
       <CheckCancleButton

--- a/src/app/_components/modal/newColumnModal/NewColumnModal.tsx
+++ b/src/app/_components/modal/newColumnModal/NewColumnModal.tsx
@@ -10,6 +10,12 @@ import { columnActions, columnData } from '@/app/_slice/columnSlice';
 import CheckCancleButton from '../checkCancleButton/CheckCancleButton';
 
 const NewColumnModal = ({ setOpenModalType }: ModalPropsType) => {
+  const INPUT_WIDTH = {
+    [VIEWPORT_TYPES.deskTop]: 48.4,
+    [VIEWPORT_TYPES.tablet]: 48.4,
+    [VIEWPORT_TYPES.mobile]: 28.7,
+  };
+
   const dispatch = useAppDispatch();
   const params = useParams();
   const titleRef = useRef<HTMLInputElement>(null);
@@ -32,12 +38,6 @@ const NewColumnModal = ({ setOpenModalType }: ModalPropsType) => {
 
     createColumn(titleRef.current?.value, Number(params.id));
     setOpenModalType('');
-  };
-
-  const INPUT_WIDTH = {
-    [VIEWPORT_TYPES.deskTop]: 48.4,
-    [VIEWPORT_TYPES.tablet]: 48.4,
-    [VIEWPORT_TYPES.mobile]: 28.7,
   };
 
   const viewPortType = useGetViewportSize();

--- a/src/app/_components/modal/taskCardModal/TaskCardModal.tsx
+++ b/src/app/_components/modal/taskCardModal/TaskCardModal.tsx
@@ -2,6 +2,9 @@ import React, { useState, useEffect, useRef, ChangeEvent } from 'react';
 import { TaskCardModalPropsType } from '@/app/_types/modalProps';
 import { useOutsideClick } from '@/app/_hooks/useOutsideClick';
 import Image from 'next/image';
+import useAppDispatch from '@/app/_hooks/useAppDispatch';
+import useAppSelector from '@/app/_hooks/useAppSelector';
+import { cardActions, cardData } from '@/app/_slice/cardSlice';
 import ManagerInfoBox from './ManagerInfoBox';
 import ModalContainer from '../modalContainer/ModalContainer';
 import StatusTag from '../../DropDown/StatusTag';
@@ -14,26 +17,29 @@ import PopupDropDown from '../../DropDown/PopupDropDown';
 import OtherComment from '../../OtherComment';
 import TagIcon from '../../TagIcon';
 
-const TaskCardModal = ({ setOpenModalType }: TaskCardModalPropsType) => {
-  const CARD_INFO = {
-    title: '새로운 일정 관리 Taskify',
-    content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum finibus nibh 
-      arcu, quis consequat ante cursus eget. Cras mattis, nulla non laoreet porttitor, 
-      diam justo laoreet eros, vel aliquet diam elit at leo.`,
-    status: 'To Do',
-    tags: [
-      '프로젝트',
-      '일반',
-      '백엔드',
-      '상',
-      '프로젝트2',
-      '일반2',
-      '백엔드2',
-      '상2',
-    ],
-    manager: '배유철',
-    deadline: '2022.12.30 19:00',
-  };
+const TaskCardModal = ({
+  setOpenModalType,
+  requestId,
+}: TaskCardModalPropsType) => {
+  // const CARD_INFO = {
+  //   title: '새로운 일정 관리 Taskify',
+  //   content: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum finibus nibh
+  //     arcu, quis consequat ante cursus eget. Cras mattis, nulla non laoreet porttitor,
+  //     diam justo laoreet eros, vel aliquet diam elit at leo.`,
+  //   status: 'To Do',
+  //   tags: [
+  //     '프로젝트',
+  //     '일반',
+  //     '백엔드',
+  //     '상',
+  //     '프로젝트2',
+  //     '일반2',
+  //     '백엔드2',
+  //     '상2',
+  //   ],
+  //   manager: '배유철',
+  //   deadline: '2022.12.30 19:00',
+  // };
 
   const COMMENT_INFO = [
     {
@@ -45,11 +51,30 @@ const TaskCardModal = ({ setOpenModalType }: TaskCardModalPropsType) => {
     },
   ];
 
+  const dispatch = useAppDispatch();
+  const cardInfo = useAppSelector(cardData);
+
   const [myCommentInputValue, setMyCommentInputValue] = useState('');
   const [isPressedMoreIcon, setIsPressedMoreIcon] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
 
   useEffect(() => {}, [myCommentInputValue]);
+
+  useEffect(() => {
+    const fetchCardDetail = async () => {
+      try {
+        await dispatch(
+          cardActions.asyncFetchGetCard({
+            cardId: Number(requestId),
+          }),
+        );
+      } catch (error) {
+        console.error('Error fetching card detail:', error);
+      }
+    };
+
+    fetchCardDetail();
+  }, []);
 
   const handleCloseClick = () => {
     setOpenModalType('');
@@ -105,11 +130,11 @@ const TaskCardModal = ({ setOpenModalType }: TaskCardModalPropsType) => {
   useOutsideClick(ref, handleCloseClick);
 
   return (
-    <ModalContainer title={CARD_INFO.title} ref={ref}>
+    <ModalContainer title={cardInfo?.title} ref={ref}>
       {isMobile && (
         <ManagerInfoBox
-          managerName={CARD_INFO.manager}
-          deadline={CARD_INFO.deadline}
+          managerName={cardInfo?.assignee?.nickname}
+          deadline={cardInfo?.dueDate}
         />
       )}
       <div className={styles.rowDiv}>
@@ -118,7 +143,7 @@ const TaskCardModal = ({ setOpenModalType }: TaskCardModalPropsType) => {
             <StatusTag status="To Do" />
             <Divider />
             <div className={styles.tagDiv}>
-              {CARD_INFO.tags.map((tag) => (
+              {cardInfo?.tags.map((tag) => (
                 <TagIcon
                   key={tag}
                   tagName={tag}
@@ -129,7 +154,7 @@ const TaskCardModal = ({ setOpenModalType }: TaskCardModalPropsType) => {
               ))}
             </div>
           </div>
-          <div className={styles.contentDiv}>{CARD_INFO.content}</div>
+          <div className={styles.contentDiv}>{cardInfo?.description}</div>
           <div className={styles.ImageDiv}>
             {isMobile ? (
               <Image height={133} src={cardImg} alt="card-img" />
@@ -164,8 +189,8 @@ const TaskCardModal = ({ setOpenModalType }: TaskCardModalPropsType) => {
         </div>
         {isMobile || (
           <ManagerInfoBox
-            managerName={CARD_INFO.manager}
-            deadline={CARD_INFO.deadline}
+            managerName={cardInfo?.assignee.nickname}
+            deadline={cardInfo?.dueDate}
           />
         )}
       </div>

--- a/src/app/_types/CardProps.ts
+++ b/src/app/_types/CardProps.ts
@@ -5,4 +5,22 @@ export interface CardProps {
   tagNameArr: string[];
   date: string;
   image?: string;
+  cardInfo: {
+    id: number;
+    title: string;
+    description: string;
+    tags: string[];
+    dueDate: string;
+    assignee: {
+      id: number;
+      nickname: string;
+      profileImageUrl: string;
+    };
+    imageUrl: string;
+    teamId: string;
+    dashboardId: number;
+    columnId: number;
+    createdAt: string;
+    updatedAt: string;
+  };
 }

--- a/src/app/_types/modalProps.ts
+++ b/src/app/_types/modalProps.ts
@@ -40,4 +40,5 @@ export type ModalContentFuncPropsType = {
 export type TaskCardModalPropsType = {
   openModalType?: string;
   setOpenModalType: React.Dispatch<React.SetStateAction<string>>;
+  requestId?: number;
 };

--- a/src/app/_types/modalProps.ts
+++ b/src/app/_types/modalProps.ts
@@ -10,12 +10,14 @@ export type ModalPropsType = {
   openModalType?: string;
   setOpenModalType: React.Dispatch<React.SetStateAction<string>>;
   inputInitialValue?: string;
+  requestId?: number;
 };
 
 export type ModalPortalPropsType = {
   openModalType: string;
   setOpenModalType: React.Dispatch<React.SetStateAction<string>>;
   inputInitialValue?: string;
+  requestId?: number;
 };
 
 export type CheckCancelButtonPropType = {
@@ -32,6 +34,7 @@ export type ModalContentFuncPropsType = {
   openModalType?: string;
   setOpenModalType: React.Dispatch<React.SetStateAction<string>>;
   inputInitialValue?: string;
+  requestId?: number;
 };
 
 export type TaskCardModalPropsType = {


### PR DESCRIPTION
## 💻 작업 내용

- 대시보드에서 컬럼 추가하는 기능 구현
- 대시보드에서 컬럼 관리(타이틀 수정)하는 기능 구현
- 대시보드의 카드를 클릭했을 때 상세 정보가 뜨도록 구현
  - 이미지, 댓글, 수정, 삭제 기능은 아직 구현하지 못했습니다

## 🖼️ 스크린샷

<img width="827" alt="image" src="https://github.com/sprint-part3-team1/Planyang/assets/80617716/5c430d04-9243-4bb3-bd2b-fbc808659689">

<img width="1045" alt="image" src="https://github.com/sprint-part3-team1/Planyang/assets/80617716/22756445-f1a9-4cd7-90e0-cab3ecbc8ba9">

<img width="977" alt="image" src="https://github.com/sprint-part3-team1/Planyang/assets/80617716/5b58df1f-8421-4999-aaea-1776fced5d14">

## 🚨 관련 이슈 및 참고 사항

-
