### PR TITLE
edit-page-refactoring_topic

### DIFF
--- a/src/app/(route)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(route)/dashboard/[id]/edit/page.tsx
@@ -6,7 +6,7 @@ import TableMember from '@/app/(route)/mydashboard/_components/TableMember';
 import BackDashBoardButton from '@/app/_components/Button/BackDashBoardButton/BackDashBoardButton';
 import DeleteDashBoardButton from '@/app/_components/Button/DeleteDashBoardButton/DeleteDashBoardButton';
 import styles from './style/page.module.css';
-// useRouter import 수정
+
 const DashBoardeditPage = () => {
   return (
     <div className={styles.container}>

--- a/src/app/(route)/dashboard/[id]/layout.tsx
+++ b/src/app/(route)/dashboard/[id]/layout.tsx
@@ -3,6 +3,9 @@
 import DashboardListNavBar from '@/app/_components/_navbar/_dashboardNavbar/_dashboardListType/DashboardListNavBar';
 import React, { ReactNode, useEffect } from 'react';
 import { dashBoardDetailActions } from '@/app/_slice/dashBoardDetail';
+import useAppDispatch from '@/app/_hooks/useAppDispatch';
+
+import { columnActions } from '@/app/_slice/columnSlice';
 
 const DashBoardDetailLayout = ({
   children,
@@ -11,6 +14,34 @@ const DashBoardDetailLayout = ({
   children: ReactNode;
   params: { id: string };
 }) => {
+  const dispatch = useAppDispatch();
+  useEffect(() => {
+    const fetchDashboardDetail = async () => {
+      try {
+        await dispatch(
+          dashBoardDetailActions.asyncFetchGetDashBoardDetail({
+            dashBoardId: Number(params.id),
+          }),
+        );
+      } catch (error) {
+        console.error('Error fetching dashboard detail:', error);
+      }
+    };
+
+    const fetchColumns = async () => {
+      try {
+        await dispatch(
+          columnActions.asyncFetchGetColumn({ dashboardId: Number(params.id) }),
+        );
+      } catch (error) {
+        console.error('Error fetching columns:', error);
+      }
+    };
+
+    fetchDashboardDetail();
+    fetchColumns();
+  }, [params.id, dispatch]);
+
   return (
     <div style={{ width: '100%' }}>
       <DashboardListNavBar

--- a/src/app/(route)/dashboard/[id]/page.tsx
+++ b/src/app/(route)/dashboard/[id]/page.tsx
@@ -1,74 +1,20 @@
 'use client';
 
-import useAppDispatch from '@/app/_hooks/useAppDispatch';
 import useAppSelector from '@/app/_hooks/useAppSelector';
-import { useEffect, useState } from 'react';
-import {
-  dashBoardDetailData,
-  dashBoardDetailActions,
-} from '@/app/_slice/dashBoardDetail';
-import { memberActions, memberData } from '@/app/_slice/memberSlice';
-import { registerActions, userResponse } from '@/app/_slice/registerSlice';
-import { columnActions, columnData } from '@/app/_slice/columnSlice';
+import { useState } from 'react';
+import { columnData } from '@/app/_slice/columnSlice';
 import styles from '@/app/(route)/dashboard/[id]/page.module.css';
 import AddColumnButton from '@/app/_components/Button/AddColumnButton/AddColumnButton';
 import MODAL_TYPES from '@/app/constants/modalTypes';
 import ModalPortal from '@/app/_components/modal/modalPortal/ModalPortal';
 import Column from '../_components/Column';
 
-const DashBoard = ({ params }: { params: { id: string } }) => {
-  const dispatch = useAppDispatch();
+const DashBoard = () => {
   const columnDataList = useAppSelector(columnData);
 
   const [openModalType, setOpenModalType] = useState('');
   const [cardInfo, setCardInfo] = useState(null);
   const [totalCount, setTotalCount] = useState<Record<number, number>>();
-
-  useEffect(() => {
-    const fetchDashboardDetail = async () => {
-      try {
-        await dispatch(
-          dashBoardDetailActions.asyncFetchGetDashBoardDetail({
-            dashBoardId: Number(params.id),
-          }),
-        );
-      } catch (error) {
-        console.error('Error fetching dashboard detail:', error);
-      }
-    };
-    const fetchMember = async () => {
-      try {
-        await dispatch(
-          memberActions.asyncGetMembers({
-            dashboardId: Number(params.id),
-          }),
-        );
-      } catch (error) {
-        console.error('Error fetching member List:', error);
-      }
-    };
-    const fetchRegister = async () => {
-      try {
-        await dispatch(registerActions.asynchFetchgetUserInfo());
-      } catch (error) {
-        console.error('Error fetching register:', error);
-      }
-    };
-    const fetchColumns = async () => {
-      try {
-        await dispatch(
-          columnActions.asyncFetchGetColumn({ dashboardId: Number(params.id) }),
-        );
-      } catch (error) {
-        console.error('Error fetching columns:', error);
-      }
-    };
-
-    fetchDashboardDetail();
-    fetchMember();
-    fetchRegister();
-    fetchColumns();
-  }, [params.id, dispatch]);
 
   return (
     <>

--- a/src/app/(route)/dashboard/layout.tsx
+++ b/src/app/(route)/dashboard/layout.tsx
@@ -1,41 +1,14 @@
 'use client';
 
-import React, { useEffect } from 'react';
-import useAppDispatch from '@/app/_hooks/useAppDispatch';
+import React from 'react';
 import useAppSelector from '@/app/_hooks/useAppSelector';
-import { dashBoardActions, dashBoardData } from '@/app/_slice/dashBoardSlice';
-import { userResponse, registerActions } from '@/app/_slice/registerSlice';
-import DashboardListNavBar from '@/app/_components/_navbar/_dashboardNavbar/_dashboardListType/DashboardListNavBar';
-import { usePathname } from 'next/navigation';
-import { dashBoardDetailActions } from '@/app/_slice/dashBoardDetail';
+import { dashBoardData } from '@/app/_slice/dashBoardSlice';
+
 import SideMenu from '../mydashboard/_components/SideMenu';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
-  const dispatch = useAppDispatch();
-
   const dashBoardDatas = useAppSelector(dashBoardData);
 
-  const pathName = usePathname();
-
-  useEffect(() => {
-    // URL에서 숫자 부분 추출
-    const regex = /\/dashboard\/(\d+)/;
-    const match = pathName.match(regex);
-    if (match) {
-      const number = match[1];
-
-      dispatch(
-        dashBoardDetailActions.asyncFetchGetDashBoardDetail({
-          dashBoardId: number,
-        }),
-      );
-    }
-  }, [pathName]);
-
-  useEffect(() => {
-    dispatch(dashBoardActions.asynchFetchGetDashBoard(1));
-    dispatch(registerActions.asynchFetchgetUserInfo());
-  }, [dispatch]);
   return (
     <div style={{ display: 'flex' }}>
       <SideMenu dashBoardData={dashBoardDatas?.dashboards} />

--- a/src/app/(route)/mydashboard/_components/EditDashName.tsx
+++ b/src/app/(route)/mydashboard/_components/EditDashName.tsx
@@ -5,8 +5,10 @@ import EditButton from '@/app/_components/Button/EditButton/EditButton';
 import useAppSelector from '@/app/_hooks/useAppSelector';
 import { dashBoardDetailData } from '@/app/_slice/dashBoardDetail';
 
+import DashboardColors from '@/app/_components/DashboardColors';
+import useAppDispatch from '@/app/_hooks/useAppDispatch';
+import { dashBoardActions } from '@/app/_slice/dashBoardSlice';
 import styles from './EditDashName.module.css';
-import DashBoardEditCircle from './DashBoardEditCircle';
 
 export interface ColorBoxType {
   color: string;
@@ -14,43 +16,59 @@ export interface ColorBoxType {
   id: number;
 }
 const EditDashName = () => {
-  const dashBoardDats = useAppSelector(dashBoardDetailData);
-
-  const [colorBox, setColorBox]: [
-    ColorBoxType[],
-    React.Dispatch<React.SetStateAction<ColorBoxType[]>>,
-  ] = useState([
-    { color: '#7AC555', isChecked: false, id: 0 },
-    { color: '#760DDE', isChecked: false, id: 1 },
-    { color: '#FFA500', isChecked: false, id: 2 },
-    { color: '#76A5EA', isChecked: false, id: 3 },
-    { color: '#E876EA', isChecked: false, id: 4 },
-  ]);
-  console.log(colorBox);
-  // 받아야 할 데이터 : 해당 대시보드의 이름, 색상정하는 컴포넌트 (임의의 이미지 대신에 )
   const dashBoardDatas = useAppSelector(dashBoardDetailData);
-  const [checkColor, setCheckColor] = useState('');
-  const [editDashBoardName, setEditDashBoardName] = useState('');
+  const [dashboardColor, setDashboardColor] = useState<string>('green');
 
+  const [editDashBoardName, setEditDashBoardName] = useState('');
+  const dispatch = useAppDispatch();
   const handleChangeInput = (e: ChangeEvent<HTMLInputElement>) => {
     setEditDashBoardName(e.target.value);
   };
+
+  const editDashboard = (dashBoardId: number, title: string, color: string) => {
+    dispatch(
+      dashBoardActions.asyncFetchUpdateDashBoard({
+        dashBoardId,
+        title,
+        color,
+      }),
+    );
+  };
+
+  const editButtonHandler = () => {
+    let color: string;
+    switch (dashboardColor) {
+      case 'green':
+        color = '#7AC555';
+        break;
+      case 'purple':
+        color = '#760DDE';
+        break;
+      case 'orange':
+        color = '#FFA500';
+        break;
+      case 'blue':
+        color = '#76A5EA';
+        break;
+      case 'pink':
+        color = '#E876EA';
+        break;
+      default:
+        color = '';
+    }
+    editDashboard(dashBoardDatas?.id, editDashBoardName, color);
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.title}>
         <span>{dashBoardDatas?.title}</span>
-        {/* 색상 이미지로 대체 필요 */}
 
         <div className={styles.circleBox}>
-          {colorBox.map((item) => {
-            return (
-              <DashBoardEditCircle
-                color={item.color}
-                setCheckColor={setCheckColor}
-                key={item.id}
-              />
-            );
-          })}
+          <DashboardColors
+            dashboardColor={dashboardColor}
+            setDashboardColor={setDashboardColor}
+          />
         </div>
       </div>
       <span id={styles.inputTitle}>대시보드 이름</span>
@@ -62,11 +80,7 @@ const EditDashName = () => {
         }}
       />
       <div className={styles.editBtn}>
-        <EditButton
-          checkColor={checkColor}
-          editDashBoardName={editDashBoardName}
-          boardId={dashBoardDats?.id}
-        />
+        <EditButton editButtonHandler={editButtonHandler} />
       </div>
     </div>
   );

--- a/src/app/(route)/mydashboard/_components/SideMenu.tsx
+++ b/src/app/(route)/mydashboard/_components/SideMenu.tsx
@@ -5,15 +5,14 @@ import { useState, useEffect } from 'react';
 import MODAL_TYPES from '@/app/constants/modalTypes';
 import ModalPortal from '@/app/_components/modal/modalPortal/ModalPortal';
 import ArrowButton from '@/app/_components/Button/ArrowButton/ArrowButton';
+
 import styles from './SideMenu.module.css';
 import DashBoardColorCircle from './DashBoardColorCircle';
 import fetchDashboards from '../_api/dashboardPagination';
 
 const SideMenu = () => {
   const [openModalType, setOpenModalType] = useState('');
-  const [selectedDashboardId, setSelectedDashboardId] = useState<number | null>(
-    null,
-  );
+  const [selectedDashboardId] = useState<number | null>(null);
   const [page, setPage] = useState<number>(1);
   const [totalCount, setTotalCount] = useState<number>(0);
   const [totalPages, setTotalPages] = useState<number>(0);
@@ -26,15 +25,10 @@ const SideMenu = () => {
   const LOGO_TITLE = '/assets/images/logoTitle.svg';
   const VECTOR_ICON_SRC = '/assets/icons/vector.svg';
   const CROWN_ICON_SRC = '/assets/icons/crown.svg';
-
-  const handleDashboardItemClick = (id: number) => {
-    setSelectedDashboardId(id);
-  };
-
+  console.log(dashBoardDatas?.dashboards.reverse());
   const handleLeftButtonClick = () => {
     // 좌측 버튼을 클릭했을 때의 동작 구현
     if (isLeftActive) {
-      console.log('페이지 -1');
       setPage(page - 1);
     }
   };
@@ -42,7 +36,6 @@ const SideMenu = () => {
   const handleRightButtonClick = () => {
     // 우측 버튼을 클릭했을 때의 동작 구현
     if (isRightActive) {
-      console.log('페이지 +1');
       setPage(page + 1);
     }
   };
@@ -65,8 +58,7 @@ const SideMenu = () => {
   useEffect(() => {
     if (dashBoardDatas) {
       setTotalCount(dashBoardDatas?.totalCount);
-      console.log(dashBoardDatas);
-      console.log(totalCount);
+
       setTotalPages(Math.ceil(totalCount / 8));
     }
   }, [dashBoardDatas, totalCount]);
@@ -132,9 +124,6 @@ const SideMenu = () => {
               className={`${styles.dashList} ${selectedDashboardId === item.id ? styles.selected : ''}`}
               href={`/dashboard/${item.id}`}
               key={item.id}
-              onClick={() => {
-                handleDashboardItemClick(item.id);
-              }}
             >
               <div>
                 <DashBoardColorCircle color={item.color} />
@@ -161,9 +150,6 @@ const SideMenu = () => {
             onLeftButtonClick={handleLeftButtonClick}
             onRightButtonClick={handleRightButtonClick}
           />
-          {/* <span id={styles.pageFont}>
-            {page} Page / {totalPages} Pages
-          </span> */}
         </div>
       </div>
     </div>

--- a/src/app/(route)/mydashboard/_components/TableInvite.tsx
+++ b/src/app/(route)/mydashboard/_components/TableInvite.tsx
@@ -23,17 +23,7 @@ const TableInvite = () => {
     dispatch(invitationActions.asynchGetMyInvitation({ dashBoardId, page }));
   };
 
-  const cancelInvitation = (dashBoardId: number, invitationId: number) => {
-    dispatch(
-      invitationActions.asynchFetchDeleteInvited({
-        dashBoardId,
-        invitationId,
-      }),
-    );
-  };
-
   const [isMobile, setIsMobile] = useState(false);
-  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     const handleResize = () => {
@@ -50,25 +40,38 @@ const TableInvite = () => {
 
   useEffect(() => {
     if (dashBoardDatas?.id) {
-      getMyInvitationList(dashBoardDatas.id, currentPage);
+      getMyInvitationList(dashBoardDatas.id, invitationDatas.page);
     }
-  }, [dashBoardDatas, dispatch, currentPage]);
+  }, [dashBoardDatas, dispatch, invitationDatas.page]);
 
-  const handleClickCancel = async (
-    dashBoardId: number,
-    invitationId: number,
-  ) => {
-    await cancelInvitation(dashBoardId, invitationId);
-    if (invitationDatas.data?.invitations.length === 1) {
-      setCurrentPage((prevPage) => prevPage - 1);
-    }
+  const onRightButtonClick = async () => {
+    if (invitationDatas.page * 5 < invitationDatas.data?.totalCount)
+      dispatch(invitationActions.incrementPage());
   };
 
   const onLeftButtonClick = async () => {
-    setCurrentPage((prevPage) => prevPage - 1);
+    if (invitationDatas.page !== 1) {
+      dispatch(invitationActions.decreasePage());
+    }
   };
-  const onRightButtonClick = async () => {
-    setCurrentPage((prevPage) => prevPage + 1);
+
+  const handleDeleteAndNavigate = async (
+    dashBoardId: number,
+    invitationId: number,
+  ) => {
+    await dispatch(
+      invitationActions.asynchFetchDeleteInvited({ dashBoardId, invitationId }),
+    );
+    await dispatch(
+      invitationActions.asynchGetMyInvitation({
+        dashBoardId,
+        page: invitationDatas.page,
+      }),
+    );
+
+    if (invitationDatas.data?.invitations.length === 1) {
+      dispatch(invitationActions.setMaxPage());
+    }
   };
 
   return (
@@ -76,8 +79,7 @@ const TableInvite = () => {
       <div className={styles.title}>
         <span id={styles.titleInvite}>초대 내역</span>
         <div className={styles.pagination}>
-          <span>1 페이지 중 {currentPage}</span>{' '}
-          {/* 수정: currentPage로 변경 */}
+          <span>1 페이지 중 {invitationDatas.page}</span>{' '}
           <ArrowButton
             onRightButtonClick={onRightButtonClick}
             onLeftButtonClick={onLeftButtonClick}
@@ -96,7 +98,7 @@ const TableInvite = () => {
           <CancelButton
             boardId={dashBoardDatas?.id}
             invitationId={item.id}
-            onClick={handleClickCancel}
+            handleDeleteAndNavigate={handleDeleteAndNavigate}
           />
         </div>
       ))}

--- a/src/app/(route)/mydashboard/_components/TableMember.tsx
+++ b/src/app/(route)/mydashboard/_components/TableMember.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { memberActions, memberData } from '@/app/_slice/memberSlice';
 import useAppDispatch from '@/app/_hooks/useAppDispatch';
 import { useEffect, useState } from 'react';
@@ -11,7 +10,7 @@ import DeleteButton from '../../../_components/Button/DeleteButton/DeleteButton'
 
 const TableMember = () => {
   const dispatch = useAppDispatch();
-  const PROFILE_ELLIPSE = '/assets/icons/profileEllipse.svg';
+
   const dashBoardDetailDatas = useAppSelector(dashBoardDetailData);
   const memberDatas = useAppSelector(memberData);
   const getMember = (dashboardId: number | undefined, page: number) => {
@@ -22,8 +21,9 @@ const TableMember = () => {
       }),
     );
   };
+
   const [page, setPage] = useState(1);
-  console.log(memberDatas?.members.length);
+
   const onRightButtonClick = () => {
     if (page * 4 < memberDatas?.totalCount) {
       setPage((prev) => prev + 1);
@@ -35,12 +35,25 @@ const TableMember = () => {
       setPage((prev) => prev - 1);
     }
   };
+
+  const handleDeleteAndNavigate = async (memberId: number) => {
+    await dispatch(memberActions.asyncDeleteMember({ memberId }));
+    await dispatch(
+      memberActions.asyncGetMembers({
+        dashboardId: dashBoardDetailDatas.id,
+        page,
+      }),
+    );
+    if (memberDatas?.members.length === 1) {
+      setPage((prev) => Math.max(prev - 1, 1));
+    }
+  };
+
   useEffect(() => {
     if (dashBoardDetailDatas?.id) {
-      // 값이 있는지 확인
       getMember(dashBoardDetailDatas.id, page);
     }
-  }, [dashBoardDetailDatas?.id, page]); // dashBoardDetailDatas.id를 의존성 배열에 추가
+  }, [dashBoardDetailDatas?.id, page]);
 
   return (
     <div className={styles.container}>
@@ -56,25 +69,23 @@ const TableMember = () => {
         </div>
       </div>
       <span className={styles.name}> 이름</span>
-      {memberDatas?.members.map((i) => {
-        return (
-          <div key={i.id} className={styles.memberContainer}>
-            <div className={styles.profileFrame}>
-              <UserIcon
-                nickname={i.nickname}
-                profileImageUrl={i.profileImageUrl}
-              />
-
-              <span id={styles.memberName}>{i.nickname}</span>
-            </div>
+      {memberDatas?.members.map((i) => (
+        <div key={i.id} className={styles.memberContainer}>
+          <div className={styles.profileFrame}>
+            <UserIcon
+              nickname={i.nickname}
+              profileImageUrl={i.profileImageUrl}
+            />
+            <span id={styles.memberName}>{i.nickname}</span>
+          </div>
+          {!i.isOwner && (
             <DeleteButton
               id={i.id}
-              setPage={setPage}
-              member={memberDatas.members}
+              handleDeleteAndNavigate={handleDeleteAndNavigate}
             />
-          </div>
-        );
-      })}
+          )}
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/app/(route)/testpage/page.tsx
+++ b/src/app/(route)/testpage/page.tsx
@@ -323,11 +323,7 @@ const TestPage = () => {
         <button
           type="button"
           onClick={() => {
-<<<<<<< HEAD
-            submitRegistration('ff', 'kkkk', 'AS123456');
-=======
             submitRegistration('min@test.com', '민정민', 'AS123456');
->>>>>>> 87260e84b39b934c39385d00a0a2ae106b261018
           }}
         >
           회원가입

--- a/src/app/_components/Button/CancelButton/CancelButton.tsx
+++ b/src/app/_components/Button/CancelButton/CancelButton.tsx
@@ -1,12 +1,16 @@
 import styles from './CancelButton.module.css';
 
-const CancelButton = ({ boardId, invitationId, onClick }) => {
+const CancelButton = ({ boardId, invitationId, handleDeleteAndNavigate }) => {
+  
+  const handleCancleButton = (boardId, invitationId) => {
+    handleDeleteAndNavigate(boardId, invitationId);
+  };
   return (
     <button
       type="button"
       className={styles.cancelBtn}
       onClick={() => {
-        onClick(boardId, invitationId);
+        handleCancleButton(boardId, invitationId);
       }}
     >
       취소

--- a/src/app/_components/Button/DeleteButton/DeleteButton.tsx
+++ b/src/app/_components/Button/DeleteButton/DeleteButton.tsx
@@ -1,29 +1,17 @@
-import { memberActions } from '@/app/_slice/memberSlice';
-
 import useAppDispatch from '@/app/_hooks/useAppDispatch';
 import styles from './DeleteButton.module.css';
 
-const DeleteButton = ({ id, setPage, member }: { id: number }) => {
-  const dispatch = useAppDispatch();
-  console.log(member);
+const DeleteButton = ({ id, handleDeleteAndNavigate }: { id: number }) => {
+  
   const handledeleteMember = (memberId: number) => {
-    if (member.length === 0) {
-      console.log(123);
-    }
-    dispatch(
-      memberActions.asyncDeleteMember({
-        memberId,
-      }),
-    );
+    handleDeleteAndNavigate(memberId);
   };
 
   return (
     <button
       type="button"
       className={styles.deleteBtn}
-      onClick={() => {
-        handledeleteMember(id);
-      }}
+      onClick={() => handledeleteMember(id)}
     >
       삭제
     </button>

--- a/src/app/_components/Button/EditButton/EditButton.tsx
+++ b/src/app/_components/Button/EditButton/EditButton.tsx
@@ -1,38 +1,12 @@
-import useAppDispatch from '@/app/_hooks/useAppDispatch';
-import { dashBoardActions } from '@/app/_slice/dashBoardSlice';
 import styles from './EditButton.module.css';
 
-interface EditButtonProps {
-  checkColor: string;
-  editDashBoardName: string;
-  boardId: number;
-}
-const EditButton = ({
-  checkColor,
-  editDashBoardName,
-  boardId,
-}: EditButtonProps) => {
-  const dispatch = useAppDispatch();
-  const updateDashBoard = (
-    dashBoardId: number,
-    title: string,
-    color: string,
-  ) => {
-    dispatch(
-      dashBoardActions.asyncFetchUpdateDashBoard({
-        dashBoardId,
-        title,
-        color,
-      }),
-    );
-  };
-
+const EditButton = ({ editButtonHandler }) => {
   return (
     <button
       type="button"
       className={styles.editBtn}
       onClick={() => {
-        updateDashBoard(boardId, editDashBoardName, checkColor);
+        editButtonHandler();
       }}
     >
       변경

--- a/src/app/_components/modal/inviteByEmailModal/InviteByEmailModal.tsx
+++ b/src/app/_components/modal/inviteByEmailModal/InviteByEmailModal.tsx
@@ -23,29 +23,28 @@ const InviteByEmailModal = ({ setOpenModalType }: ModalPropsType) => {
 
   const invitationDatas = useAppSelector(invitationData);
   const dashBoardDetailDatas = useAppSelector(dashBoardDetailData);
-  const inviteUserToDashBoard = (email: string, dashBoardId: number) => {
-    dispatch(
+
+  const InviteButtonHandler = async () => {
+    await dispatch(
       invitationActions.asynchFetchinviteUserToDashboard({
-        email,
-        dashBoardId,
+        email: inputValue,
+        dashBoardId: dashBoardDetailDatas?.id,
       }),
     );
-  };
-
-  const getMyInvitationList = (
-    dashBoardId: number | undefined,
-    page: number,
-  ) => {
-    dispatch(invitationActions.asynchGetMyInvitation({ dashBoardId, page }));
-  };
-  const InviteButtonHandler = async () => {
-    await inviteUserToDashBoard(inputValue, dashBoardDetailDatas?.id);
+    await dispatch(
+      invitationActions.asynchGetMyInvitation({
+        dashBoardId: dashBoardDetailDatas?.id,
+        page: invitationDatas.page,
+      }),
+    );
+    const totalCount = invitationDatas.data?.totalCount || 0;
+    const maxPage = Math.ceil(totalCount / 5);
     if (invitationDatas.data?.invitations.length === 5) {
-      dispatch(invitationActions.incrementPage());
-      await getMyInvitationList(
-        dashBoardDetailDatas?.id,
-        invitationDatas.page + 1,
-      );
+      if (invitationDatas.page === maxPage) {
+        dispatch(invitationActions.setPage(maxPage + 1));
+      } else {
+        dispatch(invitationActions.setPage(maxPage));
+      }
     }
 
     setOpenModalType('');

--- a/src/app/_slice/dashBoardSlice.ts
+++ b/src/app/_slice/dashBoardSlice.ts
@@ -132,11 +132,13 @@ const dashBoardSlice = createSlice({
 
     builder.addCase(asyncFetchUpdateDashBoard.fulfilled, (state, action) => {
       const updateDashBoard = action.payload;
-      const index = state.data?.dashboards.findIndex(
-        (item) => item.id === updateDashBoard.id,
-      );
-      if (index !== -1) {
-        state.data.dashboards[index] = updateDashBoard;
+      if (state.data) {
+        const index = state.data.dashboards.findIndex(
+          (item) => item.id === updateDashBoard.id,
+        );
+        if (index !== -1) {
+          state.data.dashboards[index] = updateDashBoard;
+        }
       }
     });
 

--- a/src/app/_slice/invitationSlice.ts
+++ b/src/app/_slice/invitationSlice.ts
@@ -43,7 +43,7 @@ const initialState: InvitationsType = {
 const asynchGetMyInvitation = createAsyncThunk(
   'invitationSlice/asynchGetMyInvitation',
 
-  async (getInvite: { dashBoardId: number | undefined; page: number }) => {
+  async (getInvite: { dashBoardId: number | undefined; page: any }) => {
     const accessToken = localStorage.getItem('accessToken');
     const { dashBoardId, page } = getInvite;
 
@@ -116,6 +116,15 @@ const invitationSlice = createSlice({
       if (state.page > 1) {
         state.page -= 1;
       }
+    },
+    navigateMaxPage(state) {
+      state.page = Math.max(state.page, 1);
+    },
+    setPage(state, action: PayloadAction<number>) {
+      state.page = action.payload;
+    },
+    setMaxPage(state) {
+      state.page = Math.ceil(state.data?.totalCount / 5);
     },
   },
   extraReducers: (builder) => {

--- a/src/app/_slice/registerSlice.ts
+++ b/src/app/_slice/registerSlice.ts
@@ -20,10 +20,6 @@ const initialState: RegisterStateType = {
   status: null, // 에러 상태 추가
 };
 
-const resetData = (state: RegisterStateType) => {
-  state.data = null;
-};
-
 const asynchFetchSignUp = createAsyncThunk(
   'registerSlice/asynchFetchSignup',
   async (registerData: RegisterPayloadType, { rejectWithValue }) => {
@@ -169,8 +165,8 @@ const asynchFetchUpdateInformation = createAsyncThunk(
 );
 
 const resetData = (state: RegisterStateType) => {
-    state.data = null;
-    state.status = null;
+  state.data = null;
+  state.status = null;
 };
 
 const registerSlice = createSlice({


### PR DESCRIPTION
## 💻 작업 내용

- 전체적인 edit 페이지의 코드를 리팩터링 했습니다 (필요없는 api 호출 삭제, 안쓰는 변수 삭제)

- 대시보드 수정시 색깔 목록을 클릭할때 v자 이미지가 표시되도록 했습니다

- 멤버와 내가 보낸 초대 목록의 페이지네이션에서 버그가 발생하는 문제를 해결했습니다

- 페이지네이션에서 목록을 삭제할때 데이터가 하나도 없다면 이전 페이지로 넘어가도록 했습니다

- 페이지네이션에서 목록을 삭제할때 현재 페이지에 남아있으면서 곧바로 뒤의 데이터를 불러오도록 했습니다

- 페이지네이션에서 데이터를 추가할때 최대 데이터가 이미 있다면 다음 페이지로 넘어가도록 했습니다

## 🖼️ 스크린샷
![Create Next App - Chrome 2024-04-27 05-55-39](https://github.com/sprint-part3-team1/Planyang/assets/90647684/fc91737e-9f1e-4f1f-8a6f-174b46957baa)


## 🚨 관련 이슈 및 참고 사항

- 오늘 타입관련 오류 수정, 세부 디자인 수정 예정입니다
