### PR TITLE
feat : 실시간 초대 수락 대시보드

### DIFF
--- a/src/app/(route)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(route)/dashboard/[id]/edit/page.tsx
@@ -8,25 +8,11 @@ import BackDashBoardButton from '@/app/_components/Button/BackDashBoardButton/Ba
 import DeleteDashBoardButton from '@/app/_components/Button/DeleteDashBoardButton/DeleteDashBoardButton';
 import useAppSelector from '@/app/_hooks/useAppSelector';
 import { dashBoardDetailData } from '@/app/_slice/dashBoardDetail';
-import Link from 'next/link';
 import styles from './style/page.module.css';
 
 const DashBoardeditPage = () => {
-  // const [loading, setLoading] = useState(true);
   const dashboardDetailDatas = useAppSelector(dashBoardDetailData);
 
-  // useEffect(() => {
-  //   if (dashboardDetailDatas) {
-  //      setLoading(false);
-  //   }
-  // }, [dashboardDetailDatas]);
-
-  // if (loading) {
-  //   // 로딩 중인 경우에는 "Loading..."이라는 문구를 보여줍니다.
-  //   return <div style={{ fontSize: '50px' }}>Loading...</div>;
-  // }
-
-  // 로딩이 완료된 후에 대시보드 생성자 여부에 따라 다른 화면을 렌더링합니다.
   return (
     <div className={styles.container}>
       <BackDashBoardButton />

--- a/src/app/(route)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(route)/dashboard/[id]/edit/page.tsx
@@ -12,43 +12,28 @@ import Link from 'next/link';
 import styles from './style/page.module.css';
 
 const DashBoardeditPage = () => {
-  const [loading, setLoading] = useState(true);
+  // const [loading, setLoading] = useState(true);
   const dashboardDetailDatas = useAppSelector(dashBoardDetailData);
-  useEffect(() => {
-    if (dashboardDetailDatas) {
-      setLoading(false);
-    }
-  }, [dashboardDetailDatas]);
 
-  if (loading) {
-    // 로딩 중인 경우에는 "Loading..."이라는 문구를 보여줍니다.
-    return <div style={{ fontSize: '50px' }}>Loading...</div>;
-  }
+  // useEffect(() => {
+  //   if (dashboardDetailDatas) {
+  //      setLoading(false);
+  //   }
+  // }, [dashboardDetailDatas]);
+
+  // if (loading) {
+  //   // 로딩 중인 경우에는 "Loading..."이라는 문구를 보여줍니다.
+  //   return <div style={{ fontSize: '50px' }}>Loading...</div>;
+  // }
 
   // 로딩이 완료된 후에 대시보드 생성자 여부에 따라 다른 화면을 렌더링합니다.
   return (
     <div className={styles.container}>
-      {dashboardDetailDatas?.createdByMe ? ( // 대시보드 생성자인 경우
-        <>
-          <BackDashBoardButton />
-          <EditDashName />
-          <TableMember />
-          <TableInvite />
-          <DeleteDashBoardButton />
-        </>
-      ) : (
-        // 대시보드 생성자가 아닌 경우
-        <>
-          <div style={{ fontSize: '50px' }}>
-            대시보드 생성자만 대시보드 관리가 가능합니다
-          </div>
-          <Link href="/mydashboard">
-            <button type="button" className={styles['custom-button']}>
-              나의 대시보드로 돌아가기
-            </button>
-          </Link>
-        </>
-      )}
+      <BackDashBoardButton />
+      <EditDashName />
+      <TableMember />
+      <TableInvite />
+      <DeleteDashBoardButton />
     </div>
   );
 };

--- a/src/app/(route)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(route)/dashboard/[id]/edit/page.tsx
@@ -1,18 +1,15 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import EditDashName from '@/app/(route)/mydashboard/_components/EditDashName';
 import TableInvite from '@/app/(route)/mydashboard/_components/TableInvite';
 import TableMember from '@/app/(route)/mydashboard/_components/TableMember';
 import BackDashBoardButton from '@/app/_components/Button/BackDashBoardButton/BackDashBoardButton';
 import DeleteDashBoardButton from '@/app/_components/Button/DeleteDashBoardButton/DeleteDashBoardButton';
-import useAppSelector from '@/app/_hooks/useAppSelector';
-import { dashBoardDetailData } from '@/app/_slice/dashBoardDetail';
+
 import styles from './style/page.module.css';
 
 const DashBoardeditPage = () => {
-  const dashboardDetailDatas = useAppSelector(dashBoardDetailData);
-
   return (
     <div className={styles.container}>
       <BackDashBoardButton />

--- a/src/app/(route)/dashboard/[id]/layout.tsx
+++ b/src/app/(route)/dashboard/[id]/layout.tsx
@@ -74,7 +74,6 @@ const DashBoardDetailLayout = ({
     fetchColumns();
     fetchUserInfo();
     fetchMemberInfo();
-    console.log(111111);
   }, [params.id, dispatch, dashboardDatas]);
 
   return (

--- a/src/app/(route)/dashboard/[id]/loading.tsx
+++ b/src/app/(route)/dashboard/[id]/loading.tsx
@@ -1,8 +1,14 @@
-import React from 'react';
+'use client';
+
+import React, { useEffect } from 'react';
 import LoadingIcon from '@/../public/assets/images/loading.svg';
 import styles from './loading.module.css';
 
 const Loading = () => {
+  useEffect(() => {
+    // 페이지가 처음 로드될 때 한 번만 새로고침 수행
+    window.location.reload();
+  }, []);
   return (
     <div className={styles.container}>
       <LoadingIcon />

--- a/src/app/(route)/dashboard/[id]/page.tsx
+++ b/src/app/(route)/dashboard/[id]/page.tsx
@@ -49,7 +49,7 @@ const DashBoard = () => {
     try {
       const updatedItem = {
         columnId: droppedColumnId,
-        assigneeUserId: item.assignee.id,
+        assigneeUserId: item.assignee?.id,
         title: item.title,
         description: item.description,
         dueDate: item.dueDate,

--- a/src/app/(route)/mydashboard/_components/DashInvite.tsx
+++ b/src/app/(route)/mydashboard/_components/DashInvite.tsx
@@ -14,7 +14,7 @@ import useAppSelector from '@/app/_hooks/useAppSelector';
 import { dashBoardActions, dashBoardData } from '@/app/_slice/dashBoardSlice';
 import styles from './DashInvite.module.css';
 
-const DashInvite = ({ setPageOne }) => {
+const DashInvite = () => {
   const SEARCH_ICON = '/assets/icons/search.svg';
   const UNSUBSCRIBE_IMAGE = '/assets/images/unsubscribe.svg';
 
@@ -87,7 +87,7 @@ const DashInvite = ({ setPageOne }) => {
       }),
     );
 
-    dispatch(dashBoardActions.asynchFetchGetDashBoard(1));
+    // dispatch(dashBoardActions.asynchFetchGetDashBoard(1));
   };
 
   const rejectInvite = (invitationId: number) => {

--- a/src/app/(route)/mydashboard/_components/SideMenu.tsx
+++ b/src/app/(route)/mydashboard/_components/SideMenu.tsx
@@ -6,7 +6,7 @@ import { useState, useEffect } from 'react';
 import MODAL_TYPES from '@/app/constants/modalTypes';
 import ModalPortal from '@/app/_components/modal/modalPortal/ModalPortal';
 import ArrowButton from '@/app/_components/Button/ArrowButton/ArrowButton';
-
+import { receivedInvitationData } from '@/app/_slice/receivedInvitationsSlice';
 import useAppSelector from '@/app/_hooks/useAppSelector';
 import { dashBoardActions, dashBoardData } from '@/app/_slice/dashBoardSlice';
 import useAppDispatch from '@/app/_hooks/useAppDispatch';
@@ -22,6 +22,7 @@ const SideMenu = () => {
   const CROWN_ICON_SRC = '/assets/icons/crown.svg';
 
   const dashboardDatas = useAppSelector(dashBoardData);
+  const inviteInformation = useAppSelector(receivedInvitationData);
   const getDashboardData = (page: number) => {
     dispatch(dashBoardActions.asynchFetchGetDashBoard(page));
   };
@@ -51,6 +52,10 @@ const SideMenu = () => {
   useEffect(() => {
     setTotalCount(dashboardDatas?.totalCount);
   }, [dashboardDatas]);
+
+  useEffect(() => {
+    getDashboardData(page);
+  }, [inviteInformation]);
 
   const onRightButtonClick = () => {
     if (page < Math.ceil(totalCount / 7)) {

--- a/src/app/(route)/mydashboard/page.tsx
+++ b/src/app/(route)/mydashboard/page.tsx
@@ -9,6 +9,7 @@ import {
   dashBoardActions,
   dashBoardData,
 } from '@/app/_slice/dashBoardSlice';
+import { receivedInvitationData } from '@/app/_slice/receivedInvitationsSlice';
 import { dashBoardDetailActions } from '@/app/_slice/dashBoardDetail';
 import DashboardListNavBar from '@/app/_components/_navbar/_dashboardNavbar/_dashboardListType/DashboardListNavBar';
 import AddDashBoardButton from '@/app/_components/Button/AddDashBoardButton/AddDashBoardButton';
@@ -32,6 +33,8 @@ interface DashBoardStateType {
 export default function MyDashBoard() {
   const dispatch = useAppDispatch();
   const dashboardDatas = useAppSelector(dashBoardData);
+
+  const inviteInformation = useAppSelector(receivedInvitationData);
   const userData = useAppSelector(userResponse);
   const [openModalType, setOpenModalType] = useState('');
   const [page, setPage] = useState<number>(1);
@@ -45,7 +48,6 @@ export default function MyDashBoard() {
   const handleLeftButtonClick = () => {
     // 좌측 버튼을 클릭했을 때의 동작 구현
     if (isLeftActive) {
-      console.log('페이지 -1');
       setPage(page - 1);
     }
   };
@@ -53,27 +55,21 @@ export default function MyDashBoard() {
   const handleRightButtonClick = () => {
     // 우측 버튼을 클릭했을 때의 동작 구현
     if (isRightActive) {
-      console.log('페이지 +1');
       setPage(page + 1);
     }
   };
 
-  // 페이지 1로 바뀌게 하는 함수
-  const setPageOne = () => {
-    setPage(1);
+  const fetchData = async () => {
+    try {
+      const data = await fetchDashboards(page, 5);
+      setDashBoardDatas(data);
+    } catch (error) {
+      console.error('Error fetching dashboards:', error);
+    }
   };
 
   // 대시보드 버튼의 페이지 네이션
   useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const data = await fetchDashboards(page, 5);
-        setDashBoardDatas(data);
-      } catch (error) {
-        console.error('Error fetching dashboards:', error);
-      }
-    };
-
     fetchData();
   }, [page, dispatch, dashboardDatas]);
 
@@ -101,6 +97,11 @@ export default function MyDashBoard() {
       setIsRightActive(false);
     }
   }, [page, totalPages]);
+
+  // 초대받은 내역 데이터가 바뀌면 재랜더링
+  useEffect(() => {
+    fetchData();
+  }, [inviteInformation]);
 
   return (
     <div style={{ width: '100%' }}>
@@ -147,7 +148,7 @@ export default function MyDashBoard() {
             onRightButtonClick={handleRightButtonClick}
           />
         </div>
-        <DashInvite setPageOne={setPageOne} />
+        <DashInvite />
       </div>
     </div>
   );


### PR DESCRIPTION
## 💻 작업 내용

- 대시보드에 보여주는 데이터는 dashboardData이고 초대 수락 거절에서 사용하는 데이터는 inviteinformation이라서 inviteinformation이 변경될때마다 재랜더링해주도록 수정하였습니다.

## 🖼️ 스크린샷

![실시간 초대 수락 대시보드](https://github.com/sprint-part3-team1/Planyang/assets/108421517/3ca2b87c-1ead-4113-b0ab-9483208fe1d1)


## 🚨 관련 이슈 및 참고 사항

-
